### PR TITLE
feat: add API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ example usage:
 
 python zoomer_bible_builder.py --repo-dir .\Bible-kjv --model "gemma-3-4b-it" --no-stream --ctx-pairs 10
 
+pass an api key if your endpoint needs it:
+
+python zoomer_bible_builder.py --api-key YOUR_KEY_HERE
+
+or set API_KEY env var for either script:
+
+API_KEY=YOUR_KEY python zoomer_bom_builder.py --no-stream
+
 added tts by chapter for use with kokoro fastapi
 
 python tts_by_chapter.py zoomer_bible.txt --outdir D:\AITools\zoomer-bible-builder\bible_audio --voice "af_sky+af+af_nicole" --speed 1.75 --format mp3 --skip-existing

--- a/zoomer_bible_builder.py
+++ b/zoomer_bible_builder.py
@@ -318,6 +318,7 @@ def run(
     out_txt: str,
     api_base: str,
     model: str,
+    api_key: Optional[str],
     start_index: Optional[int],
     end_index: Optional[int],
     temperature: float,
@@ -329,6 +330,8 @@ def run(
 ):
     with open(system_prompt_path, "r", encoding="utf-8") as f:
         sys_prompt = f.read().strip()
+
+    extra_headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
 
     print("Loading book list...")
     books_list = fetch_books_list(repo_dir)
@@ -378,7 +381,8 @@ def run(
                         stream=stream,
                         max_tokens=-1,
                         stops=DEFAULT_STOPS,
-                        history_messages=history
+                        history_messages=history,
+                        extra_headers=extra_headers,
                     )
                     raw_for_log = raw
                     line = postprocess_line(raw, expected_prefix)
@@ -395,7 +399,8 @@ def run(
                             stream=False,
                             max_tokens=-1,
                             stops=None,
-                            history_messages=history
+                            history_messages=history,
+                            extra_headers=extra_headers,
                         )
                         line2 = postprocess_line(raw2, expected_prefix)
                         if body_ok(line2, expected_prefix):
@@ -418,7 +423,8 @@ def run(
                             stream=False,
                             max_tokens=-1,
                             stops=None,
-                            history_messages=history + [nudge]
+                            history_messages=history + [nudge],
+                            extra_headers=extra_headers,
                         )
                         line3 = postprocess_line(raw3, expected_prefix)
                         if body_ok(line3, expected_prefix):
@@ -469,6 +475,7 @@ if __name__ == "__main__":
     p.add_argument("--out", default="zoomer_bible.txt", help="Output file to append verses to.")
     p.add_argument("--api-base", default=DEFAULT_API_BASE, help="OpenAI-compatible chat completions endpoint.")
     p.add_argument("--model", default=DEFAULT_MODEL, help="Model name.")
+    p.add_argument("--api-key", default=os.environ.get("API_KEY"), help="Optional API key for the endpoint.")
     p.add_argument("--start-index", type=parse_index_arg, default=None, help="Zero-based verse index to start from.")
     p.add_argument("--end-index", type=parse_index_arg, default=None, help="Stop before this zero-based index.")
     p.add_argument("--temperature", type=float, default=0.9, help="Sampling temperature.")
@@ -484,6 +491,7 @@ if __name__ == "__main__":
         out_txt=args.out,
         api_base=args.api_base,
         model=args.model,
+        api_key=args.api_key,
         start_index=args.start_index,
         end_index=args.end_index,
         temperature=args.temperature,

--- a/zoomer_bom_builder.py
+++ b/zoomer_bom_builder.py
@@ -249,6 +249,7 @@ def run(
     out_txt: str,
     api_base: str,
     model: str,
+    api_key: Optional[str],
     start_index: Optional[int],
     end_index: Optional[int],
     temperature: float,
@@ -261,6 +262,8 @@ def run(
 ):
     with open(system_prompt_path, "r", encoding="utf-8") as f:
         sys_prompt = f.read().strip()
+
+    extra_headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
 
     print("Loading JSON…")
     data = load_bom_json(bom_json_path, use_standard_works)
@@ -300,7 +303,8 @@ def run(
                         stream=stream,
                         max_tokens=-1,
                         stops=DEFAULT_STOPS,
-                        history_messages=history
+                        history_messages=history,
+                        extra_headers=extra_headers,
                     )
                     line = postprocess_line(raw, expected_prefix)
 
@@ -315,7 +319,8 @@ def run(
                             stream=False,
                             max_tokens=-1,
                             stops=None,
-                            history_messages=history
+                            history_messages=history,
+                            extra_headers=extra_headers,
                         )
                         line2 = postprocess_line(raw2, expected_prefix)
                         if body_ok(line2, expected_prefix):
@@ -337,7 +342,8 @@ def run(
                                 stream=False,
                                 max_tokens=-1,
                                 stops=None,
-                                history_messages=history + [nudge]
+                                history_messages=history + [nudge],
+                                extra_headers=extra_headers,
                             )
                             line3 = postprocess_line(raw3, expected_prefix)
                             if body_ok(line3, expected_prefix):
@@ -382,6 +388,7 @@ if __name__ == "__main__":
     p.add_argument("--out", default=OUT_PATH_DEFAULT, help="Output file to append verses to.")
     p.add_argument("--api-base", default=DEFAULT_API_BASE, help="OpenAI-compatible chat completions endpoint.")
     p.add_argument("--model", default=DEFAULT_MODEL, help="Model name.")
+    p.add_argument("--api-key", default=os.environ.get("API_KEY"), help="Optional API key for the endpoint.")
     p.add_argument("--start-index", type=parse_index_arg, default=None, help="Zero-based verse index to start from.")
     p.add_argument("--end-index", type=parse_index_arg, default=None, help="Stop before this zero-based index.")
     p.add_argument("--temperature", type=float, default=0.9, help="Sampling temperature.")
@@ -398,6 +405,7 @@ if __name__ == "__main__":
         out_txt=args.out,
         api_base=args.api_base,
         model=args.model,
+        api_key=args.api_key,
         start_index=args.start_index,
         end_index=args.end_index,
         temperature=args.temperature,


### PR DESCRIPTION
## Summary
- allow passing API keys to Zoomer Bible and BOM builders
- document API key usage in README

## Testing
- `python -m py_compile zoomer_bible_builder.py zoomer_bom_builder.py`
- `python zoomer_bible_builder.py --help`
- `python zoomer_bom_builder.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68aaa45ec7108328b309f081f87b5062